### PR TITLE
add nix support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+watch_file package.json package-lock.json

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,5 @@
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+fi
 use flake
 watch_file package.json package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 .vscode/
 prova.py
+/.pre-commit-config.yaml
+/.direnv
+/result

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # activitn
 Project for unitn software engineering
+
+## Setup
+
+See [docs/develop.md](docs/develop.md)

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,19 @@
+# Development environment setup instuctions
+
+### 1. Clone the repo
+`git clone git@github.com:SamueleFacenda/activitn.git`
+
+### 2. Intall nix
+- Install [nix the package manager](https://nixos.org/download/).
+- Enable [nix flakes](https://nixos.wiki/wiki/Flakes#Enable_flakes_permanently_in_NixOS).
+- Optional: [install direnv](https://direnv.net/docs/installation.html) to avoid typing `nix develop` every time.
+
+### 3. Enter the environment
+
+If you have direnv just run `direnv allow` from the repository root (as it should be suggested by direnv hitself),
+the environment will automaticcally load and unload when entering and exiting the repo tree.
+
+In the other cases just run `nix develop` to enter a bash shell with the environment setup. Just type `exit` (as always)
+to exit the shell. 
+
+You don't need to install nodejs, do `npm install` or anything else and the enviromnet is sure to work.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,137 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,9 @@
             ];
 
             npmDeps = pkgs.importNpmLock.buildNodeModules {
-              npmRoot = ./.;
+              # npmRoot = ./.; # avoid rebuilding when js code changes
+              package = pkgs.lib.importJSON ./package.json;
+              packageLock = pkgs.lib.importJSON ./package-lock.json;
               inherit (pkgs) nodejs;
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+# nix comments
+{
+  description = "Activitn, a software for managing events!";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = { self, nixpkgs, flake-utils, pre-commit-hooks }:
+    let
+      version = "0.0.1";
+
+      overlay = final: prev: { };
+
+    in
+
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = (nixpkgs.legacyPackages.${system}.extend overlay); in
+      {
+
+        packages = rec {
+          default = activitn;
+          activitn = pkgs.buildNpmPackage {
+            pname = "activitn";
+            src = ./.;
+            inherit version;
+
+            npmDeps = pkgs.importNpmLock {
+              npmRoot = ./.;
+            };
+
+            dontNpmBuild = true;
+
+            npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+
+            meta = {
+              description = "Application for publishing and participating to events";
+              homepage = "https://github.com/SamueleFacenda/activitn";
+              license = pkgs.lib.licenses.gpl3Only;
+            };
+          };
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${self.defaultPackage.${system}}/bin/executable";
+          };
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              importNpmLock.hooks.linkNodeModulesHook
+              nodejs
+            ];
+
+            npmDeps = pkgs.importNpmLock.buildNodeModules {
+              npmRoot = ./.;
+              inherit (pkgs) nodejs;
+            };
+
+            # buildInputs = self.checks.${system}.pre-commit-check.enabledPackages;
+            # inherit (self.checks.${system}.pre-commit-check) shellHook;
+          };
+
+        };
+
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              nixpkgs-fmt.enable = true;
+              shellcheck.enable = true;
+            };
+          };
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,11 @@
               inherit (pkgs) nodejs;
             };
 
-            # buildInputs = self.checks.${system}.pre-commit-check.enabledPackages;
-            # inherit (self.checks.${system}.pre-commit-check) shellHook;
+            buildInputs = self.checks.${system}.pre-commit-check.enabledPackages;
+            # hack to make linkNodeModulesHook work (it's not applied if there already is a shellHook)
+            shellHook = ''
+              runHook linkNodeModulesHook
+            '' + self.checks.${system}.pre-commit-check.shellHook;
           };
 
         };
@@ -75,7 +78,8 @@
             src = ./.;
             hooks = {
               nixpkgs-fmt.enable = true;
-              shellcheck.enable = true;
+              # eslint.enable = true;
+              # shellcheck.enable = true;
             };
           };
         };

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "activitn",
+  "version": "0.0.1",
   "type": "module",
   "dependencies": {
     "express": "^4.21.1",


### PR DESCRIPTION
Setup di nix per avere un developement environment riproducibile. Guardate il documento relativo per più info per il setup. Usa meno spazio di docker e è più veloce (e comodo, non hai container né virtualizzazione).
Ci sono setuppati anche dei pre-commit hooks che controllano la sintassi, non del js intanto.